### PR TITLE
更加灵活的处理右上角点击事件&适配iPhone X

### DIFF
--- a/YBImageBrowser/FunctionBar/YBImageBrowserFunctionBar.m
+++ b/YBImageBrowser/FunctionBar/YBImageBrowserFunctionBar.m
@@ -8,6 +8,11 @@
 
 #import "YBImageBrowserFunctionBar.h"
 
+// 判断是否是iPhone X
+#define IsIphoneX ([UIScreen instancesRespondToSelector:@selector(currentMode)] ? CGSizeEqualToSize(CGSizeMake(1125, 2436), [[UIScreen mainScreen] currentMode].size) : NO)
+// home indicator 高度
+#define home_indicator_height (IsIphoneX ? 34.f : 0.f)
+
 @interface YBImageBrowserFunctionBar () <UITableViewDelegate, UITableViewDataSource> {
     CGRect showFrameOfTableView;
     CGRect hideFrameOfTableView;
@@ -140,6 +145,16 @@
     return 5;
 }
 
+- (UIView *)tableView:(UITableView *)tableView viewForHeaderInSection:(NSInteger)section
+{
+    if (section == 0) {
+        return nil;
+    }
+    UIView *header = [[UIView alloc]initWithFrame:CGRectMake(0, 0, 0, 5)];
+    header.backgroundColor = [UIColor groupTableViewBackgroundColor];
+    return header;
+}
+
 - (CGFloat)tableView:(UITableView *)tableView heightForFooterInSection:(NSInteger)section {
     return 0.001;
 }
@@ -169,11 +184,11 @@
     } else {
         label.text = _cancelText;
     }
+    line.hidden = indexPath.section == 1;
     return cell;
 }
 
 #pragma mark UITableViewDelegate
-
 - (void)tableView:(UITableView *)tableView didSelectRowAtIndexPath:(NSIndexPath *)indexPath {
     if (indexPath.section == 0) {
         if (_delegate && [_delegate respondsToSelector:@selector(ybImageBrowserFunctionBar:clickCellWithModel:)]) {
@@ -202,10 +217,13 @@
         _tableView.estimatedRowHeight = 44;
         _tableView.estimatedSectionFooterHeight = 0;
         _tableView.estimatedSectionHeaderHeight = 0;
-        _tableView.backgroundColor = [UIColor clearColor];
+        _tableView.backgroundColor = [UIColor whiteColor];
         if (@available(iOS 11.0, *)) {
             _tableView.contentInsetAdjustmentBehavior = UIScrollViewContentInsetAdjustmentNever;
         }
+        UIView *footer = [[UIView alloc]initWithFrame:CGRectMake(0, 0, 0, home_indicator_height)];
+        footer.backgroundColor = [UIColor whiteColor];
+        _tableView.tableFooterView = footer;
         _tableView.alwaysBounceVertical = NO;
         _tableView.separatorStyle = UITableViewCellSeparatorStyleNone;
         [_tableView registerClass:UITableViewCell.class forCellReuseIdentifier:@"YBImageBrowserFunctionBar"];

--- a/YBImageBrowser/YBImageBrowser.h
+++ b/YBImageBrowser/YBImageBrowser.h
@@ -38,6 +38,14 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (void)yBImageBrowser:(YBImageBrowser *)imageBrowser clickFunctionBarWithModel:(YBImageBrowserFunctionModel *)model;
 
+/**
+ 用户点击右上角按钮回调
+
+ @param imageBrowser 当前图片浏览器
+ @param model 功能的数据model
+ */
+- (void)yBImageBrowser:(YBImageBrowser *)imageBrowser clickRightFunctionModel:(YBImageBrowserFunctionModel *)model;
+
 @end
 
 

--- a/YBImageBrowser/YBImageBrowser.m
+++ b/YBImageBrowser/YBImageBrowser.m
@@ -353,9 +353,16 @@ static BOOL _statusBarIsHideBefore = NO;    //状态栏在模态切换之前是�
 
 - (void)yBImageBrowserToolBar:(YBImageBrowserToolBar *)imageBrowserToolBar didClickRightButton:(UIButton *)button {
     if (!self.fuctionDataArray.count) return;
-    if (self.fuctionDataArray.count == 1 && [self.fuctionDataArray[0].ID isEqualToString:YBImageBrowserFunctionModel_ID_savePictureToAlbum]) {
-        //直接保存图片
-        [self savePhotoToAlbumWithCurrentIndex];
+    if (self.fuctionDataArray.count == 1) {
+        if([self.fuctionDataArray[0].ID isEqualToString:YBImageBrowserFunctionModel_ID_savePictureToAlbum]){
+            //直接保存图片
+            [self savePhotoToAlbumWithCurrentIndex];
+        }else{
+            //用户自己实现相关功能
+            if([_delegate respondsToSelector:@selector(yBImageBrowser:clickRightFunctionModel:)]){
+                [_delegate yBImageBrowser:self clickRightFunctionModel:self.fuctionDataArray[0]];
+            }
+        }
     } else {
         //弹出功能栏
         if (_functionBar) {

--- a/YBImageBrowserDemo/TestCase/ViewController.m
+++ b/YBImageBrowserDemo/TestCase/ViewController.m
@@ -47,7 +47,6 @@ static NSString * const kReuseIdentifierOfHeader = @"UICollectionReusableViewHea
     YBImageBrowser *browser = [YBImageBrowser new];
     browser.dataArray = tempArr;
     browser.currentIndex = indexPath.row;
-    
     //展示
     [browser show];
 }


### PR DESCRIPTION
通过添加代理方法：
- (void)yBImageBrowser:(YBImageBrowser *)imageBrowser clickRightFunctionModel:(YBImageBrowserFunctionModel *)model
来实现方便用户在只想放一个按钮在右上角并且功能不是保存到相册的需求。
另外修改了actionbar在iPhone X上的效果。