### PR TITLE
Fix CGImageCreateWithImageInRect not Cropping Correctly

### DIFF
--- a/YBImageBrowser/ImageBrowse/YBImageBrowseCellData.m
+++ b/YBImageBrowser/ImageBrowse/YBImageBrowseCellData.m
@@ -310,14 +310,48 @@ static BOOL _shouldDecodeAsynchronously = YES;
     
     self->_isCutting = YES;
     YBIB_GET_QUEUE_ASYNC(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
-        CGImageRef cgImage = CGImageCreateWithImageInRect(self.image.CGImage, rect);
-        UIImage *resultImg = [UIImage imageWithCGImage:cgImage];
-        CGImageRelease(cgImage);
+        UIImage *resultImg = [self cuttingImageToRect:self.image toRect:rect];
         YBIB_GET_QUEUE_MAIN_ASYNC(^{
             self->_isCutting = NO;
             if (complete) complete(resultImg);
         })
     })
+}
+
+- (UIImage *)cuttingImageToRect:(UIImage *)image toRect:(CGRect)rect {
+    CGFloat (^rad)(CGFloat) = ^CGFloat(CGFloat deg) {
+        return deg / 180.0f * (CGFloat) M_PI;
+    };
+    
+    // determine the orientation of the image and apply a transformation to the crop rectangle to shift it to the correct position
+    CGAffineTransform rectTransform;
+    switch (image.imageOrientation) {
+        case UIImageOrientationLeft:
+            rectTransform = CGAffineTransformTranslate(CGAffineTransformMakeRotation(rad(90)), 0, -image.size.height);
+            break;
+        case UIImageOrientationRight:
+            rectTransform = CGAffineTransformTranslate(CGAffineTransformMakeRotation(rad(-90)), -image.size.width, 0);
+            break;
+        case UIImageOrientationDown:
+            rectTransform = CGAffineTransformTranslate(CGAffineTransformMakeRotation(rad(-180)), -image.size.width, -image.size.height);
+            break;
+        default:
+            rectTransform = CGAffineTransformIdentity;
+    };
+    
+    // adjust the transformation scale based on the image scale
+    rectTransform = CGAffineTransformScale(rectTransform, image.scale, image.scale);
+    
+    // apply the transformation to the rect to create a new, shifted rect
+    CGRect transformedCropSquare = CGRectApplyAffineTransform(rect, rectTransform);
+    // use the rect to crop the image
+    CGImageRef imageRef = CGImageCreateWithImageInRect(image.CGImage, transformedCropSquare);
+    // create a new UIImage and set the scale and orientation appropriately
+    UIImage *result = [UIImage imageWithCGImage:imageRef scale:image.scale orientation:image.imageOrientation];
+    // memory cleanup
+    CGImageRelease(imageRef);
+    
+    return result;
 }
 
 - (YBImageBrowseFillType)getFillTypeWithLayoutDirection:(YBImageBrowserLayoutDirection)layoutDirection {


### PR DESCRIPTION
我在使用时发现高度比较大的图片放大时中间出现一个方向旋转过的小图([Bug截图](https://image.tracup.com/snapshot_1543915273034.png))；
查看图层结构和代码发现你使用了CGImageCreateWithImageInRect截取图片，实际得到的截取图像，恰好是当rect旋转90°。
这个是因为CGImageCreateWithImageInRect中的rect是获取自UIImage中得rect，而不是UIImageView的，而在UIImage的坐标系中，(0,0)点位于左下角，因此在裁剪区域确定时，需要转换成对应坐标系中得区域；
我已修复这个Bug。