### PR TITLE
SDWebImageCache的缓存key和image的url,其实并不一定是一致的.

### DIFF
--- a/YBImageBrowser/Helper/YBIBWebImageManager.m
+++ b/YBImageBrowser/Helper/YBIBWebImageManager.m
@@ -67,15 +67,15 @@ static BOOL _cacheShouldDecompressImages;
 }
 
 + (void)storeImage:(UIImage *)image imageData:(NSData *)data forKey:(NSURL *)key toDisk:(BOOL)toDisk {
-    key = SDWebImageManager.sharedManager.cacheKeyFilter(key);
-    [[SDImageCache sharedImageCache] storeImage:image imageData:data forKey:key.absoluteString toDisk:toDisk completion:nil];
+    NSString *cacheKey = SDWebImageManager.sharedManager.cacheKeyFilter(key);
+    [[SDImageCache sharedImageCache] storeImage:image imageData:data forKey:cacheKey toDisk:toDisk completion:nil];
 }
 
 + (void)queryCacheOperationForKey:(NSURL *)key completed:(YBIBWebImageManagerCacheQueryCompletedBlock)completed {
     if (!key) return;
     SDImageCacheOptions options = SDImageCacheQueryDataWhenInMemory;
-    key = SDWebImageManager.sharedManager.cacheKeyFilter(key);
-    [[SDImageCache sharedImageCache] queryCacheOperationForKey:key.absoluteString options:options done:^(UIImage * _Nullable image, NSData * _Nullable data, SDImageCacheType cacheType) {
+    NSString *cacheKey = SDWebImageManager.sharedManager.cacheKeyFilter(key);
+    [[SDImageCache sharedImageCache] queryCacheOperationForKey:cacheKey options:options done:^(UIImage * _Nullable image, NSData * _Nullable data, SDImageCacheType cacheType) {
         if (completed) {
             completed(image, data);
         }

--- a/YBImageBrowser/Helper/YBIBWebImageManager.m
+++ b/YBImageBrowser/Helper/YBIBWebImageManager.m
@@ -17,6 +17,11 @@
 #else
 #import "SDImageCache.h"
 #endif
+#if __has_include(<SDWebImage/SDWebImageManager.h>)
+#import <SDWebImage/SDWebImageManager.h>
+#else
+#import "SDWebImageManager.h"
+#endif
 
 static BOOL _downloaderShouldDecompressImages;
 static BOOL _cacheShouldDecompressImages;
@@ -68,6 +73,7 @@ static BOOL _cacheShouldDecompressImages;
 + (void)queryCacheOperationForKey:(NSURL *)key completed:(YBIBWebImageManagerCacheQueryCompletedBlock)completed {
     if (!key) return;
     SDImageCacheOptions options = SDImageCacheQueryDataWhenInMemory;
+    key = SDWebImageManager.sharedManager.cacheKeyFilter(key);
     [[SDImageCache sharedImageCache] queryCacheOperationForKey:key.absoluteString options:options done:^(UIImage * _Nullable image, NSData * _Nullable data, SDImageCacheType cacheType) {
         if (completed) {
             completed(image, data);

--- a/YBImageBrowser/Helper/YBIBWebImageManager.m
+++ b/YBImageBrowser/Helper/YBIBWebImageManager.m
@@ -67,6 +67,7 @@ static BOOL _cacheShouldDecompressImages;
 }
 
 + (void)storeImage:(UIImage *)image imageData:(NSData *)data forKey:(NSURL *)key toDisk:(BOOL)toDisk {
+    key = SDWebImageManager.sharedManager.cacheKeyFilter(key);
     [[SDImageCache sharedImageCache] storeImage:image imageData:data forKey:key.absoluteString toDisk:toDisk completion:nil];
 }
 


### PR DESCRIPTION
在SDWebImageManager中有cacheKeyFilter方法,需要使用该方法从url中获取真正的缓存key.