### PR TITLE
我发现了一个问题,由于不太好描述,所以我把demo改了一下,你清楚bug后把这个request关闭就行了,不要合并代码.

### DIFF
--- a/YBImageBrowser/Helper/YBIBWebImageManager.m
+++ b/YBImageBrowser/Helper/YBIBWebImageManager.m
@@ -67,15 +67,15 @@ static BOOL _cacheShouldDecompressImages;
 }
 
 + (void)storeImage:(UIImage *)image imageData:(NSData *)data forKey:(NSURL *)key toDisk:(BOOL)toDisk {
-    key = SDWebImageManager.sharedManager.cacheKeyFilter(key);
-    [[SDImageCache sharedImageCache] storeImage:image imageData:data forKey:key.absoluteString toDisk:toDisk completion:nil];
+    NSString *cacheKey = SDWebImageManager.sharedManager.cacheKeyFilter(key);
+    [[SDImageCache sharedImageCache] storeImage:image imageData:data forKey:cacheKey toDisk:toDisk completion:nil];
 }
 
 + (void)queryCacheOperationForKey:(NSURL *)key completed:(YBIBWebImageManagerCacheQueryCompletedBlock)completed {
     if (!key) return;
     SDImageCacheOptions options = SDImageCacheQueryDataWhenInMemory;
-    key = SDWebImageManager.sharedManager.cacheKeyFilter(key);
-    [[SDImageCache sharedImageCache] queryCacheOperationForKey:key.absoluteString options:options done:^(UIImage * _Nullable image, NSData * _Nullable data, SDImageCacheType cacheType) {
+    NSString *cacheKey = SDWebImageManager.sharedManager.cacheKeyFilter(key);
+    [[SDImageCache sharedImageCache] queryCacheOperationForKey:cacheKey options:options done:^(UIImage * _Nullable image, NSData * _Nullable data, SDImageCacheType cacheType) {
         if (completed) {
             completed(image, data);
         }

--- a/YBImageBrowser/Helper/YBIBWebImageManager.m
+++ b/YBImageBrowser/Helper/YBIBWebImageManager.m
@@ -17,6 +17,11 @@
 #else
 #import "SDImageCache.h"
 #endif
+#if __has_include(<SDWebImage/SDWebImageManager.h>)
+#import <SDWebImage/SDWebImageManager.h>
+#else
+#import "SDWebImageManager.h"
+#endif
 
 static BOOL _downloaderShouldDecompressImages;
 static BOOL _cacheShouldDecompressImages;
@@ -68,6 +73,7 @@ static BOOL _cacheShouldDecompressImages;
 + (void)queryCacheOperationForKey:(NSURL *)key completed:(YBIBWebImageManagerCacheQueryCompletedBlock)completed {
     if (!key) return;
     SDImageCacheOptions options = SDImageCacheQueryDataWhenInMemory;
+    key = SDWebImageManager.sharedManager.cacheKeyFilter(key);
     [[SDImageCache sharedImageCache] queryCacheOperationForKey:key.absoluteString options:options done:^(UIImage * _Nullable image, NSData * _Nullable data, SDImageCacheType cacheType) {
         if (completed) {
             completed(image, data);

--- a/YBImageBrowser/Helper/YBIBWebImageManager.m
+++ b/YBImageBrowser/Helper/YBIBWebImageManager.m
@@ -67,6 +67,7 @@ static BOOL _cacheShouldDecompressImages;
 }
 
 + (void)storeImage:(UIImage *)image imageData:(NSData *)data forKey:(NSURL *)key toDisk:(BOOL)toDisk {
+    key = SDWebImageManager.sharedManager.cacheKeyFilter(key);
     [[SDImageCache sharedImageCache] storeImage:image imageData:data forKey:key.absoluteString toDisk:toDisk completion:nil];
 }
 


### PR DESCRIPTION
加入我强引用YBImageBrowser,并且图片url请求是失败的,那么第二次点击图片的时候,YBImageBrowser.view的alpha会变为0.所有YBImageBrowser上面内容将全是透明的.
本来想自己解决这个问题,但是看了源码,没有找到导致这个bug的原因...
你看看是怎么回事吧,因为我感觉用户点击图片还是挺频繁的,强引用YBImageBrowser应该也算是正常需求